### PR TITLE
Remove outdated sub-command from Conan graph

### DIFF
--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -58,11 +58,10 @@ while build_order:
     _, pkg_ref = build_order[0][0]
     pkg_ref = pkg_ref.split("#", 1)[0]
     print("\n********** Rebuild affected package: %s ***********" % pkg_ref)
-    run("conan graph clean-modified release/")
     run("conan install %s --build=%s --lockfile=release" % (pkg_ref, pkg_ref))
     os.chdir("..")
     run("conan graph update-lock release build_server_folder/release")
     rm("build_server_folder")
     # Update the build order after changes
     run("conan graph build-order ./release --json=bo.json --build=missing")
-    build_order = json.loads(load("bo.json"))        
+    build_order = json.loads(load("bo.json"))


### PR DESCRIPTION
`conan graph clean-modified` is no longer supported since Conan 1.18

/cc @jgsogo 