### PR TITLE
Scripts to run the examples should not modify the cache

### DIFF
--- a/.ci/run.py
+++ b/.ci/run.py
@@ -102,11 +102,10 @@ def ensure_cache_preserved():
     # The examples cannot modify the cache
     def compute_hashes():
         hashes = {}
-        for root, dirs, filenames in os.walk(cache_directory, topdown=False):
-            for i, directory in enumerate(dirs):
-                for filename in filenames[i]:
-                    filepath = os.path.join(directory, filename)
-                    hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()
+        for root, _, filenames in os.walk(cache_directory):
+            for filename in filenames:
+                filepath = os.path.join(root, filename)
+                hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()
         return hashes
     
     before_hashes = compute_hashes()

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -117,11 +117,21 @@ def ensure_cache_preserved():
         after_hashes = compute_hashes()
 
         added_keys = set(after_hashes.keys()) - set(before_hashes.keys())
-        diff_values = [k for k,v in after_hashes.items() if before_hashes.get(k, None) != v]
+        diff_values = [k for k,v in after_hashes.items() if k in before_hashes and before_hashes.get(k) != v]
 
         if added_keys or diff_values:
             diffs = set(list(added_keys) + diff_values)
-            raise Exception("Current example modifies the cache. Found differences in:\n{}".format('\n'.join(diffs)))
+            msg = "Current example modifies the cache.\n"
+            if added_keys:
+                msg += " - New files added to the cache:\n"    
+                for item in added_keys:
+                    msg += "   + {}".format(item)
+            if diff_values:
+                msg += " - Modified files:\n"    
+                for item in diff_values:
+                    msg += "   + {}".format(item)
+            
+            raise Exception(msg)
 
 
 def run_scripts(scripts):

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 from tabulate import tabulate
 import colorama
 import hashlib
+import difflib
 
 
 FAIL_FAST = os.getenv("FAIL_FAST", "0").lower() in ["1", "y", "yes", "true"]
@@ -131,8 +132,11 @@ def ensure_cache_preserved():
                 msg += " - Modified files:\n"    
                 for item in diff_values:
                     msg += "   + {}\n".format(item)
-                    msg += "---- before ----\n{}\n---- after ----\n{}\n----\n".format(before_contents[item], after_contents[item])
-            
+                    msg += "---"
+                    for line in difflib.unified_diff(before_contents[item].splitlines(), after_contents[item].splitlines(),
+                                                     fromfile='before', tofile='after', lineterm=''):
+                        msg += line
+                    msg += "---"
             raise Exception(msg)
 
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -15,6 +15,7 @@ from collections import OrderedDict
 from tabulate import tabulate
 import colorama
 import hashlib
+import codecs
 import difflib
 
 
@@ -109,7 +110,7 @@ def ensure_cache_preserved():
             for filename in filenames:
                 filepath = os.path.join(root, filename)
                 hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()
-                contents[filepath] = open(filepath).read()
+                contents[filepath] = codecs.open(filepath).read()
         return hashes, contents
     
     before_hashes, before_contents = compute_hashes()

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -154,7 +154,6 @@ def run_scripts(scripts):
             
             # Need to initialize the cache with default files if they are not already there
             subprocess.call(['conan', 'install', 'zlib/1.2.11@conan/stable'], env=env)
-            subprocess.call(['conan', 'config', 'set', 'log.print_run_commands=True'], env=env)
  
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -111,7 +111,7 @@ def ensure_cache_preserved():
     finally:
         r = git.run("diff")
         if r:
-            writeln_console("* " + colorama.Fore.RED + "This is example modifies the cache!")
+            writeln_console(">>> " + colorama.Fore.RED + "This is example modifies the cache!")
             writeln_console(r)
             raise Exception("Example modifies cache!")
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -145,7 +145,7 @@ def run_scripts(scripts):
         with chdir(os.path.dirname(script)):
             print_build(script)
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
-            subprocess.call(['conan'] ['search'], env=env)  # Need to initialize the cache with something
+            subprocess.call(['conan', 'search'], env=env)  # Need to initialize the cache with something
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)
             results[script] = result

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -147,17 +147,18 @@ def run_scripts(scripts):
         chmod_x(script)
         abspath = os.path.abspath(script)
         env = get_conan_env(script)
-        configfile_path = os.path.join(os.environ["CONAN_USER_HOME"], "conan.conf")
         configure_profile(env)
         with chdir(os.path.dirname(script)):
             print_build(script)
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
             
-            subprocess.call(['conan', 'install', 'zlib/1.2.11@conan/stable'], env=env)  # Need to initialize the cache with something
+            # Need to initialize the cache with default files if they are not already there
+            subprocess.call(['conan', 'install', 'zlib/1.2.11@conan/stable'], env=env)
             subprocess.call(['conan', 'config', 'set', 'log.print_run_commands=True'], env=env)
  
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)
+                
             results[script] = result
             if result != 0 and FAIL_FAST:
                 break

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -114,10 +114,10 @@ def ensure_cache_preserved():
         yield
     finally:
         r = git.run("diff")
-        print("*"*20)
-        print(r)
         if r:
-            raise Exception("!!!!")
+            writeln_console("* " + colorama.Style.RED + "This is example modifies the cache!")
+            writeln_console(r)
+            raise Exception("Example modifies cache!")
 
 
 def run_scripts(scripts):

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -145,7 +145,10 @@ def run_scripts(scripts):
         with chdir(os.path.dirname(script)):
             print_build(script)
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
+            
             subprocess.call(['conan', 'install', 'zlib/1.2.11@conan/stable'], env=env)  # Need to initialize the cache with something
+            subprocess.call(['conan', 'config', 'set', 'log.print_run_commands=True'], env=env)
+ 
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)
             results[script] = result

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -1,24 +1,20 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-import os
-import sys
-import glob
-import stat
-import platform
-import subprocess
-import tempfile
 import logging
+import os
+import platform
+import stat
+import subprocess
+import sys
+import tempfile
 import uuid
-from contextlib import contextmanager
 from collections import OrderedDict
-from tabulate import tabulate
-import colorama
-import hashlib
-import codecs
-import difflib
-from conans.client.tools.scm import Git
+from contextlib import contextmanager
 
+import colorama
+from conans.client.tools.scm import Git
+from tabulate import tabulate
 
 FAIL_FAST = os.getenv("FAIL_FAST", "0").lower() in ["1", "y", "yes", "true"]
 LOGGING_LEVEL = int(os.getenv("CONAN_LOGGING_LEVEL", logging.INFO))

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -111,7 +111,7 @@ def ensure_cache_preserved():
     finally:
         r = git.run("diff")
         if r:
-            writeln_console("* " + colorama.Style.RED + "This is example modifies the cache!")
+            writeln_console("* " + colorama.Fore.RED + "This is example modifies the cache!")
             writeln_console(r)
             raise Exception("Example modifies cache!")
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -136,7 +136,7 @@ def ensure_cache_preserved():
                     msg += "---"
                     for line in difflib.unified_diff(before_contents[item].splitlines(), after_contents[item].splitlines(),
                                                      fromfile='before', tofile='after', lineterm=''):
-                        msg += line
+                        msg += line + "\n"
                     msg += "---"
             raise Exception(msg)
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -128,7 +128,10 @@ def run_scripts(scripts):
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
             
             # Need to initialize the cache with default files if they are not already there
-            subprocess.call(['conan', 'install', 'zlib/1.2.11@conan/stable'], env=env)
+            try:
+                subprocess.call(['conan', 'install', 'foobar/foobar@conan/stable'], env=env)
+            except:
+                pass
  
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -110,7 +110,7 @@ def ensure_cache_preserved():
             for filename in filenames:
                 filepath = os.path.join(root, filename)
                 hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()
-                contents[filepath] = codecs.open(filepath, 'r', 'utf-8').read()
+                contents[filepath] = codecs.open(filepath, 'r', 'latin-1').read()
         return hashes, contents
     
     before_hashes, before_contents = compute_hashes()

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -129,7 +129,8 @@ def run_scripts(scripts):
             
             # Need to initialize the cache with default files if they are not already there
             try:
-                subprocess.call(['conan', 'install', 'foobar/foobar@conan/stable'], env=env)
+                subprocess.call(['conan', 'install', 'foobar/foobar@conan/stable'], env=env,
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             except:
                 pass
  

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -96,6 +96,7 @@ def print_build(script):
     writeln_console("* " + colorama.Style.BRIGHT + "{}".format(dir_name.upper()))
     writeln_console("================================================================")
 
+
 @contextmanager
 def ensure_cache_preserved():
     cache_directory = os.environ["CONAN_USER_HOME"]
@@ -119,7 +120,7 @@ def ensure_cache_preserved():
         diff_values = [k for k,v in after_hashes.items() if before_hashes.get(k, None) != v]
 
         if added_keys or diff_values:
-            diffs = list(added_keys) + diff_values
+            diffs = set(list(added_keys) + diff_values)
             raise Exception("Current example modifies the cache. Found differences in:\n{}".format('\n'.join(diffs)))
 
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -110,7 +110,7 @@ def ensure_cache_preserved():
             for filename in filenames:
                 filepath = os.path.join(root, filename)
                 hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()
-                contents[filepath] = codecs.open(filepath).read()
+                contents[filepath] = codecs.open(filepath, 'r', 'utf-8').read()
         return hashes, contents
     
     before_hashes, before_contents = compute_hashes()

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -145,7 +145,7 @@ def run_scripts(scripts):
         with chdir(os.path.dirname(script)):
             print_build(script)
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
-            subprocess.call(['conan --version'], env=env)  # Need to initialize the cache with something
+            subprocess.call(['conan'] ['search'], env=env)  # Need to initialize the cache with something
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)
             results[script] = result

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -125,11 +125,11 @@ def ensure_cache_preserved():
             if added_keys:
                 msg += " - New files added to the cache:\n"    
                 for item in added_keys:
-                    msg += "   + {}".format(item)
+                    msg += "   + {}\n".format(item)
             if diff_values:
                 msg += " - Modified files:\n"    
                 for item in diff_values:
-                    msg += "   + {}".format(item)
+                    msg += "   + {}\n".format(item)
             
             raise Exception(msg)
 
@@ -145,6 +145,7 @@ def run_scripts(scripts):
         with chdir(os.path.dirname(script)):
             print_build(script)
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
+            subprocess.call(['conan --version'], env=env)  # Need to initialize the cache with something
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)
             results[script] = result

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -102,19 +102,20 @@ def ensure_cache_preserved():
     cache_directory = os.environ["CONAN_USER_HOME"]
     # The examples cannot modify the cache
     def compute_hashes():
-        hashes = {}
+        hashes = contents = {}
         for root, dirs, filenames in os.walk(cache_directory):
             dirs[:] = [d for d in dirs if d not in ['data', ]]  # Check all files but the storage folder
             for filename in filenames:
                 filepath = os.path.join(root, filename)
                 hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()
-        return hashes
+                contents[filepath] = open(filepath).read()
+        return hashes, contents
     
-    before_hashes = compute_hashes()
+    before_hashes, before_contents = compute_hashes()
     try:
         yield
     finally:
-        after_hashes = compute_hashes()
+        after_hashes, after_contents = compute_hashes()
 
         added_keys = set(after_hashes.keys()) - set(before_hashes.keys())
         diff_values = [k for k,v in after_hashes.items() if k in before_hashes and before_hashes.get(k) != v]
@@ -130,6 +131,7 @@ def ensure_cache_preserved():
                 msg += " - Modified files:\n"    
                 for item in diff_values:
                     msg += "   + {}\n".format(item)
+                    msg += "---- before ----\n{}\n---- after ----\n{}\n----\n".format(before_contents[item], after_contents[item])
             
             raise Exception(msg)
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -102,7 +102,8 @@ def ensure_cache_preserved():
     # The examples cannot modify the cache
     def compute_hashes():
         hashes = {}
-        for root, _, filenames in os.walk(cache_directory):
+        for root, dirs, filenames in os.walk(cache_directory):
+            dirs[:] = [d for d in dirs if d not in ['data', ]]  # Check all files but the storage folder
             for filename in filenames:
                 filepath = os.path.join(root, filename)
                 hashes[filepath] = hashlib.md5(open(filepath, 'rb').read()).digest()

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -145,7 +145,7 @@ def run_scripts(scripts):
         with chdir(os.path.dirname(script)):
             print_build(script)
             build_script = [sys.executable, abspath] if abspath.endswith(".py") else abspath
-            subprocess.call(['conan', 'search'], env=env)  # Need to initialize the cache with something
+            subprocess.call(['conan', 'install', 'zlib/1.2.11@conan/stable'], env=env)  # Need to initialize the cache with something
             with ensure_cache_preserved():
                 result = subprocess.call(build_script, env=env)
             results[script] = result

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/test_package/build
 **/project*/build
 !*/build.sh
+.vscode/
 
 # Compiled Object files
 *.slo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
-  - CONAN_PRINT_RUN_COMMANDS="1"
+  - CONAN_PRINT_RUN_COMMANDS=1
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+env:
+  - CONAN_PRINT_RUN_COMMANDS="1"
 matrix:
   include:
     - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,12 @@ environment:
     PYTHON: "C:\\Python37"
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+    CONAN_PRINT_RUN_COMMANDS: 1
 
 install:
   - set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%
   - pip.exe install conan tabulate colorama --upgrade
   - conan user
 
-environment:
-  CONAN_PRINT_RUN_COMMANDS: 1
 test_script:
   - python .ci/run.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,5 +10,7 @@ install:
   - pip.exe install conan tabulate colorama --upgrade
   - conan user
 
+environment:
+  CONAN_PRINT_RUN_COMMANDS: 1
 test_script:
   - python .ci/run.py

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -23,7 +23,7 @@ def rm(path):
 def tmp_configure():
     config_params = ['default_package_id_mode', ]
     try:
-        package_id_mode = subprocess.check_output("conan config get general.default_package_id_mode", shell=True)
+        package_id_mode = str(subprocess.check_output("conan config get general.default_package_id_mode", shell=True))
     except subprocess.CalledProcessError:
         package_id_mode = None
 

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -20,19 +20,15 @@ def rm(path):
 
 
 @contextmanager
-def tmp_configure():
-    config_params = ['default_package_id_mode', ]
+def restore_conan_home():
+    conan_home = os.environ.get('CONAN_USER_HOME', None) or os.path.expanduser('~/.conan')
+    conan_conf = os.path.join(conan_home, 'conan.conf')
+
+    contents = open(conan_conf, 'rb').read()
     try:
-        package_id_mode = str(subprocess.check_output("conan config get general.default_package_id_mode", shell=True))
-    except subprocess.CalledProcessError:
-        package_id_mode = None
-
-    yield
-
-    if package_id_mode:
-        run("conan config set general.default_package_id_mode={}".format(package_id_mode))
-    else:
-        run("conan config rm general.default_package_id_mode")
+        yield
+    finally:
+        open(conan_conf, 'wb').write(contents)
 
 
 def main():
@@ -89,5 +85,5 @@ def main():
 
 
 if __name__ == '__main__':
-    with tmp_configure():
+    with restore_conan_home():
         main()

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -21,8 +21,8 @@ def rm(path):
 
 @contextmanager
 def restore_conan_home():
-    conan_home = os.environ.get('CONAN_USER_HOME', None) or os.path.expanduser('~/.conan')
-    conan_conf = os.path.join(conan_home, 'conan.conf')
+    conan_home = os.environ.get('CONAN_USER_HOME', None) or os.path.expanduser('~')
+    conan_conf = os.path.join(conan_home, '.conan', 'conan.conf')
 
     contents = open(conan_conf, 'rb').read()
     try:

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -89,6 +89,5 @@ def main():
 
 
 if __name__ == '__main__':
-    conan_conf = os.path.join(os.environ)
     with tmp_configure():
         main()

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -23,7 +23,6 @@ def rm(path):
 def restore_conan_home():
     conan_home = os.environ.get('CONAN_USER_HOME', None) or os.path.expanduser('~')
     conan_conf = os.path.join(conan_home, '.conan', 'conan.conf')
-
     contents = open(conan_conf, 'rb').read()
     try:
         yield

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -1,4 +1,7 @@
 import os, json, shutil
+import subprocess
+from contextlib import contextmanager
+
 
 def run(cmd):
     ret = os.system(cmd)
@@ -15,53 +18,77 @@ def rm(path):
     elif os.path.isdir(path):
         shutil.rmtree(path)
 
-rm("release")
-rm("build_server_folder")
-rm("bo.json")
 
-run("conan remove App/0.1@user/testing* -f")
-run("conan remove PkgA/0.1@user/testing* -f")
-run("conan remove PkgA/0.2@user/testing* -f")
-run("conan remove PkgB/0.1@user/testing* -f")
-run("conan remove PkgC/0.1@user/testing* -f")
-run("conan remove PkgZ/0.1@user/testing* -f")
-run("conan remove PkgZ/0.2@user/testing* -f")
+@contextmanager
+def tmp_configure():
+    config_params = ['default_package_id_mode', ]
+    try:
+        package_id_mode = subprocess.check_output("conan config get general.default_package_id_mode", shell=True)
+    except subprocess.CalledProcessError:
+        package_id_mode = None
 
-run("conan config set general.default_package_id_mode=full_version_mode")
-run("cd PkgZ && conan create . PkgZ/0.1@user/testing")
-run("cd PkgA && conan create . PkgA/0.1@user/testing")
-run("cd PkgB && conan create . user/testing")
-run("cd PkgC && conan create . user/testing")
-run("cd App && conan create . user/testing")
+    yield
 
-# Freeze the App dependencies in a lockfile in the release subfolder
-print("\n********** Freeze dependencies in a lockfile ***********")
-run("conan graph lock App/0.1@user/testing --lockfile=release")
+    if package_id_mode:
+        run("conan config set general.default_package_id_mode={}".format(package_id_mode))
+    else:
+        run("conan config rm general.default_package_id_mode")
 
-# A new version of Z will not affect at all
-run("cd PkgZ && conan create . PkgZ/0.2@user/testing")
-# There is a change in A, a new version that we want to test
-print("\n********** Creating PkgA/0.2 ***********")
-run("cd PkgA && conan create . PkgA/0.2@user/testing --lockfile=../release")
 
-print("\n********** Computing the build order after PkgA/0.2 ***********")
-run("conan graph build-order ./release --json=bo.json --build=missing")
-
-build_order = json.loads(load("bo.json"))
-
-while build_order:
-    # Simulates building in a different build server
-    os.makedirs("build_server_folder/release")
-    shutil.copy2("release/conan.lock", "build_server_folder/release")
-    os.chdir("build_server_folder")
-    print("\nBuild order is: %s" % build_order)
-    _, pkg_ref = build_order[0][0]
-    pkg_ref = pkg_ref.split("#", 1)[0]
-    print("\n********** Rebuild affected package: %s ***********" % pkg_ref)
-    run("conan install %s --build=%s --lockfile=release" % (pkg_ref, pkg_ref))
-    os.chdir("..")
-    run("conan graph update-lock release build_server_folder/release")
+def main():
+    rm("release")
     rm("build_server_folder")
-    # Update the build order after changes
+    rm("bo.json")
+
+    run("conan remove App/0.1@user/testing* -f")
+    run("conan remove PkgA/0.1@user/testing* -f")
+    run("conan remove PkgA/0.2@user/testing* -f")
+    run("conan remove PkgB/0.1@user/testing* -f")
+    run("conan remove PkgC/0.1@user/testing* -f")
+    run("conan remove PkgZ/0.1@user/testing* -f")
+    run("conan remove PkgZ/0.2@user/testing* -f")
+
+    run("conan config set general.default_package_id_mode=full_version_mode")
+    run("cd PkgZ && conan create . PkgZ/0.1@user/testing")
+    run("cd PkgA && conan create . PkgA/0.1@user/testing")
+    run("cd PkgB && conan create . user/testing")
+    run("cd PkgC && conan create . user/testing")
+    run("cd App && conan create . user/testing")
+
+    # Freeze the App dependencies in a lockfile in the release subfolder
+    print("\n********** Freeze dependencies in a lockfile ***********")
+    run("conan graph lock App/0.1@user/testing --lockfile=release")
+
+    # A new version of Z will not affect at all
+    run("cd PkgZ && conan create . PkgZ/0.2@user/testing")
+    # There is a change in A, a new version that we want to test
+    print("\n********** Creating PkgA/0.2 ***********")
+    run("cd PkgA && conan create . PkgA/0.2@user/testing --lockfile=../release")
+
+    print("\n********** Computing the build order after PkgA/0.2 ***********")
     run("conan graph build-order ./release --json=bo.json --build=missing")
+
     build_order = json.loads(load("bo.json"))
+
+    while build_order:
+        # Simulates building in a different build server
+        os.makedirs("build_server_folder/release")
+        shutil.copy2("release/conan.lock", "build_server_folder/release")
+        os.chdir("build_server_folder")
+        print("\nBuild order is: %s" % build_order)
+        _, pkg_ref = build_order[0][0]
+        pkg_ref = pkg_ref.split("#", 1)[0]
+        print("\n********** Rebuild affected package: %s ***********" % pkg_ref)
+        run("conan install %s --build=%s --lockfile=release" % (pkg_ref, pkg_ref))
+        os.chdir("..")
+        run("conan graph update-lock release build_server_folder/release")
+        rm("build_server_folder")
+        # Update the build order after changes
+        run("conan graph build-order ./release --json=bo.json --build=missing")
+        build_order = json.loads(load("bo.json"))
+
+
+if __name__ == '__main__':
+    conan_conf = os.path.join(os.environ)
+    with tmp_configure():
+        main()

--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -21,7 +21,7 @@ def rm(path):
 
 @contextmanager
 def restore_conan_home():
-    conan_home = os.environ.get('CONAN_USER_HOME', None) or os.path.expanduser('~')
+    conan_home = os.environ.get('CONAN_USER_HOME', os.path.expanduser('~'))
     conan_conf = os.path.join(conan_home, '.conan', 'conan.conf')
     contents = open(conan_conf, 'rb').read()
     try:

--- a/features/multi_config/build.sh
+++ b/features/multi_config/build.sh
@@ -3,9 +3,6 @@
 set -e
 set -x
 
-# Print commands
-conan config set log.print_run_commands=True
-
 # Create the multiconfig package
 conan create . user/testing
 

--- a/libraries/dear-imgui/basic/build.sh
+++ b/libraries/dear-imgui/basic/build.sh
@@ -7,7 +7,6 @@ rm -rf build
 mkdir build
 pushd build
 
-conan config set general.default_package_id_mode=full_version_mode
 conan install ..
 cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build .

--- a/libraries/dear-imgui/basic/build.sh
+++ b/libraries/dear-imgui/basic/build.sh
@@ -7,6 +7,7 @@ rm -rf build
 mkdir build
 pushd build
 
+conan config set general.default_package_id_mode=full_version_mode
 conan install ..
 cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build .


### PR DESCRIPTION
The examples are run using scripts like `build.py`, `build.bat` or `build.sh`, these scripts are inside the folder where the example is contained and users may run them to check that example works in their machine. Taken into account this, examples can't modify the user cache (they may install packages but configuration files, remotes,... everything should be the same before and after).

Not covered in this PR: metadata of references, we don't want an example to change the `remote` associated with a reference or package.

closes #28 