### PR TITLE
Handle c++11 settings in waf build helper Issue/31 

### DIFF
--- a/features/integrate_build_system/build.sh
+++ b/features/integrate_build_system/build.sh
@@ -3,7 +3,7 @@
 conan create waf-generator user/channel
 conan create waf-installer user/channel
 conan create waf-build-helper user/channel
-conan create waf-mylib user/channel
+conan create waf-mylib user/channel -s compiler.cppstd=11
 
 set -e
 set -x
@@ -13,5 +13,5 @@ rm -rf build
 mkdir build
 
 conan source . --source-folder=build
-conan install . --install-folder=build
+conan install . --install-folder=build -s compiler.cppstd=11
 conan build . --build-folder=build

--- a/features/integrate_build_system/waf-build-helper/waf_environment.py
+++ b/features/integrate_build_system/waf-build-helper/waf_environment.py
@@ -4,7 +4,7 @@ from conans import ConanFile, tools
 from conans.client.tools.oss import args_to_string
 from conans.util.files import normalize, save
 from conans.client.build.compiler_flags import libcxx_flag, libcxx_define, format_defines
-from conans.client.build.cppstd_flags import cppstd_flag
+from conans.client.build.cppstd_flags import cppstd_flag, cppstd_from_settings
 from conans.errors import ConanException
 
 
@@ -73,6 +73,10 @@ class WafBuildEnvironment(object):
 
             cxxf = self._libcxx_flags(
                 compiler=self._compiler, libcxx=self._compiler_libcxx)
+            cppstd = cppstd_from_settings(self._conanfile.settings)
+            cxxf.append(cppstd_flag(self._conanfile.settings.get_safe("compiler"),
+                                    self._conanfile.settings.get_safe("compiler.version"),
+                                    cppstd))
             for flag in cxxf:
                 sections.append(
                     "    conf.env.CXXFLAGS.append('{}')".format(flag))

--- a/features/integrate_build_system/waf-build-helper/waf_environment.py
+++ b/features/integrate_build_system/waf-build-helper/waf_environment.py
@@ -75,7 +75,8 @@ class WafBuildEnvironment(object):
                 compiler=self._compiler, libcxx=self._compiler_libcxx)
             cppstd = cppstd_from_settings(self._conanfile.settings)
             cxxf.append(cppstd_flag(self._conanfile.settings.get_safe("compiler"),
-                                    self._conanfile.settings.get_safe("compiler.version"),
+                                    self._conanfile.settings.get_safe(
+                                        "compiler.version"),
                                     cppstd))
             for flag in cxxf:
                 sections.append(


### PR DESCRIPTION
Added options to handle `c++11` settings in Conan with `compiler.cppstd` 
and build the examples with the flag set to `compiler.cppstd=11` so it builds without warnings.

Closes #31 