### PR TITLE
Split package ID from build order JSON

### DIFF
--- a/features/lockfiles/ci/build.py
+++ b/features/lockfiles/ci/build.py
@@ -1,6 +1,7 @@
 import os, json, shutil
 
 def run(cmd):
+    print("Running command: %s" % cmd)
     ret = os.system(cmd)
     if ret != 0:
         raise Exception("Failed command: %s" % cmd)
@@ -56,7 +57,7 @@ while build_order:
     os.chdir("build_server_folder")
     print("\nBuild order is: %s" % build_order)
     _, pkg_ref = build_order[0][0]
-    pkg_ref = pkg_ref.split("#", 1)[0]
+    pkg_ref = pkg_ref.split(":", 1)[0]
     print("\n********** Rebuild affected package: %s ***********" % pkg_ref)
     run("conan install %s --build=%s --lockfile=release" % (pkg_ref, pkg_ref))
     os.chdir("..")


### PR DESCRIPTION
In Conan 1.18.5 the JSON file generated for the build order was containing the recipe revision. The build script was taking only the reference by splitting the value with `#`.

In Conan 1.19 this was fixed and the build order only has the reference and the package ID, so the split should be changed to correctly use `:`.