### PR TITLE
xorg recipe requires Conan 1.29: 

### DIFF
--- a/.ci/run.py
+++ b/.ci/run.py
@@ -54,7 +54,7 @@ def get_examples_to_skip(current_version):
     skip = []
     # Given the Conan version, some examples are skipped
     required_conan = {
-        version.parse("1.28.2"): [
+        version.parse("1.29.0"): [
             './libraries/dear-imgui/basic', # solved bug for system packages and components
             ],
         version.parse("1.28.0"): [

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -57,18 +57,6 @@ def get_examples_to_skip(current_version):
         version.parse("1.29.0"): [
             './libraries/dear-imgui/basic', # solved bug for system packages and components
             ],
-        version.parse("1.28.0"): [
-            './features/lockfiles/intro', # new lockfiles version
-            './features/lockfiles/ci', # new lockfiles version
-            './features/lockfiles/build_order', # new lockfiles version
-            './features/deployment', # requires with filenames
-            './libraries/poco/md5',  # requires with filenames
-            './libraries/folly/basic', # requires with filenames
-            ],
-        version.parse("1.24.0"): [
-            './libraries/poco/md5',  # Uses get_safe() with 3 arguments
-            './features/deployment',  # Fails because of poco requirement
-            ],
         }
     for v, examples in required_conan.items():
         if current_version < v:


### PR DESCRIPTION
Changes in https://github.com/conan-io/conan-center-index/pull/2741 forces `xorg` to use Conan 1.29