### PR TITLE
Linux - Conan prev-prev is allowed to fail

### DIFF
--- a/.ci/run.py
+++ b/.ci/run.py
@@ -13,6 +13,7 @@ import re
 from collections import OrderedDict
 from contextlib import contextmanager
 from packaging import version
+from subprocess import PIPE
 
 import colorama
 from conans.client.tools.scm import Git
@@ -193,7 +194,7 @@ def run_scripts(scripts):
 
             with ensure_python_environment_preserved():
                 with ensure_cache_preserved():
-                    process = subprocess.run(build_script, env=env, capture_output=True)
+                    process = subprocess.run(build_script, env=env, stdout=PIPE, stderr=PIPE)
 
             results[script] = process.returncode
             if process.returncode != 0:

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -193,14 +193,12 @@ def run_scripts(scripts):
 
             with ensure_python_environment_preserved():
                 with ensure_cache_preserved():
-                    process = subprocess.Popen(build_script, env=env, stderr=subprocess.PIPE)
-                    process.wait()
+                    process = subprocess.run(build_script, env=env, capture_output=True)
 
             results[script] = process.returncode
             if process.returncode != 0:
-                _, stderror_decoded = process.communicate()
-                if re.search('Current Conan version \(.*\) does not satisfy the defined one'
-                             , stderror_decoded.decode()):
+                if re.search(r'Current Conan version \(.*\) does not satisfy the defined one'
+                             , process.stderr.decode()):
                     results[script] = "skip"
                 elif FAIL_FAST:
                     break

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -228,7 +228,7 @@ def get_result_message(result):
 
 def validate_results(results):
     for value in results.values():
-        if value != 0:
+        if value != 0 and value != "skip":
             sys.exit(value)
 
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -193,13 +193,14 @@ def run_scripts(scripts):
 
             with ensure_python_environment_preserved():
                 with ensure_cache_preserved():
-                    result = subprocess.run(build_script, capture_output=True, env=env)
+                    process = subprocess.Popen(build_script, env=env, stderr=subprocess.PIPE)
+                    process.wait()
 
-            results[script] = result.returncode
-            if result.returncode != 0:
-                stderror_decoded = result.stderr.decode()
+            results[script] = process.returncode
+            if process.returncode != 0:
+                _, stderror_decoded = process.communicate()
                 if re.search('Current Conan version \(.*\) does not satisfy the defined one'
-                             , stderror_decoded):
+                             , stderror_decoded.decode()):
                     results[script] = "skip"
                 elif FAIL_FAST:
                     break

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ jobs:
   include:
 
     - stage: Linux - Conan develop
-      name: Python 3.5
-      python: 3.5
+      name: Python 3.6
+      python: 3.6
       env: TOXENV=py35-conandev
       dist: xenial
     - name: Python 3.8
@@ -18,8 +18,8 @@ jobs:
 
     # All Linux first, check versions
     - stage: Linux - Conan Current
-      name: Python 3.5
-      python: 3.5
+      name: Python 3.6
+      python: 3.6
       env: TOXENV=py35-conancurrent
       dist: xenial
     - name: Python 3.8
@@ -28,8 +28,8 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan prev
-      name: Python 3.5
-      python: 3.5
+      name: Python 3.6
+      python: 3.6
       env: TOXENV=py35-conanprev
       dist: xenial
     - name: Python 3.8
@@ -38,8 +38,8 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan prev-prev
-      name: Python 3.5
-      python: 3.5
+      name: Python 3.6
+      python: 3.6
       env: TOXENV=py35-conanprevprev
       dist: xenial
     - name: Python 3.8
@@ -54,7 +54,7 @@ jobs:
       os: osx
       osx_image: xcode10
       env: PYVER=py38 TOXENV=py38-conandev
-    - name: Conan Current - Python 3.5
+    - name: Conan Current - Python 3.6
       language: generic
       os: osx
       osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ jobs:
   include:
 
     - stage: Linux - Conan develop
-      name: Python 3.6
-      python: 3.6
-      env: TOXENV=py36-conandev
+      name: Python 3.7
+      python: 3.7
+      env: TOXENV=py37-conandev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -18,9 +18,9 @@ jobs:
 
     # All Linux first, check versions
     - stage: Linux - Conan Current
-      name: Python 3.6
-      python: 3.6
-      env: TOXENV=py36-conancurrent
+      name: Python 3.7
+      python: 3.7
+      env: TOXENV=py37-conancurrent
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -28,9 +28,9 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan prev
-      name: Python 3.6
-      python: 3.6
-      env: TOXENV=py36-conanprev
+      name: Python 3.7
+      python: 3.7
+      env: TOXENV=py37-conanprev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -38,9 +38,9 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan prev-prev
-      name: Python 3.6
-      python: 3.6
-      env: TOXENV=py36-conanprevprev
+      name: Python 3.7
+      python: 3.7
+      env: TOXENV=py37-conanprevprev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -54,11 +54,11 @@ jobs:
       os: osx
       osx_image: xcode10
       env: PYVER=py38 TOXENV=py38-conandev
-    - name: Conan Current - Python 3.6
+    - name: Conan Current - Python 3.7
       language: generic
       os: osx
       osx_image: xcode10
-      env: PYVER=py36 TOXENV=py36-conancurrent
+      env: PYVER=py37 TOXENV=py37-conancurrent
     - name: Conan Current - Python 3.8
       language: generic
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 dist: trusty
 
 jobs:
+  allow_failures:
+    env: TOXENV=py35-conanprevprev TOXENV=py38-conanprevprev
   fast_finish: true
   include:
 
@@ -67,7 +69,7 @@ jobs:
 
 before_install:
   - ./.ci/travis/before_install.sh
-  
+
 install:
   - |
     if [[ "$(uname -s)" == 'Darwin' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ jobs:
   include:
 
     - stage: Linux - Conan develop
-      name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conandev
+      name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conandev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -18,9 +18,9 @@ jobs:
 
     # All Linux first, check versions
     - stage: Linux - Conan Current
-      name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conancurrent
+      name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conancurrent
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -28,9 +28,9 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan prev
-      name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conanprev
+      name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conanprev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -38,9 +38,9 @@ jobs:
       dist: xenial
 
     - stage: Linux - Conan prev-prev
-      name: Python 3.7
-      python: 3.7
-      env: TOXENV=py37-conanprevprev
+      name: Python 3.5
+      python: 3.5
+      env: TOXENV=py35-conanprevprev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -54,11 +54,11 @@ jobs:
       os: osx
       osx_image: xcode10
       env: PYVER=py38 TOXENV=py38-conandev
-    - name: Conan Current - Python 3.7
+    - name: Conan Current - Python 3.5
       language: generic
       os: osx
       osx_image: xcode10
-      env: PYVER=py37 TOXENV=py37-conancurrent
+      env: PYVER=py35 TOXENV=py35-conancurrent
     - name: Conan Current - Python 3.8
       language: generic
       os: osx
@@ -67,7 +67,7 @@ jobs:
 
 before_install:
   - ./.ci/travis/before_install.sh
-
+  
 install:
   - |
     if [[ "$(uname -s)" == 'Darwin' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
     - stage: Linux - Conan develop
       name: Python 3.6
       python: 3.6
-      env: TOXENV=py35-conandev
+      env: TOXENV=py36-conandev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -20,7 +20,7 @@ jobs:
     - stage: Linux - Conan Current
       name: Python 3.6
       python: 3.6
-      env: TOXENV=py35-conancurrent
+      env: TOXENV=py36-conancurrent
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -30,7 +30,7 @@ jobs:
     - stage: Linux - Conan prev
       name: Python 3.6
       python: 3.6
-      env: TOXENV=py35-conanprev
+      env: TOXENV=py36-conanprev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -40,7 +40,7 @@ jobs:
     - stage: Linux - Conan prev-prev
       name: Python 3.6
       python: 3.6
-      env: TOXENV=py35-conanprevprev
+      env: TOXENV=py36-conanprevprev
       dist: xenial
     - name: Python 3.8
       python: 3.8
@@ -58,7 +58,7 @@ jobs:
       language: generic
       os: osx
       osx_image: xcode10
-      env: PYVER=py35 TOXENV=py35-conancurrent
+      env: PYVER=py36 TOXENV=py36-conancurrent
     - name: Conan Current - Python 3.8
       language: generic
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 dist: trusty
 
 jobs:
-  allow_failures:
-    env: TOXENV=py35-conanprevprev TOXENV=py38-conanprevprev
   fast_finish: true
   include:
 


### PR DESCRIPTION
~The CI job conanprevprev is unstable, it fails frequently because runs Conan's Development.~

The CI job conanprevprev is unstable, it fails frequently because runs old old conan version, which is not required by some recipes.

It should not be considered as an important branch here, as all features are not matured.