### PR TITLE
Fix examples tests

### DIFF
--- a/.ci/run.py
+++ b/.ci/run.py
@@ -64,7 +64,7 @@ def get_examples_to_skip(current_version):
         if os.environ["CMAKE_GENERATOR"] == "Visual Studio 2019":
             skip.extend(['./features/integrate_build_system', ])
     if platform.system() == "Darwin":
-        skip.extend(['./features/multi_config', ]) # randomly failing in Macos
+        skip.extend(['./features/multi_config', ]) # FIXME: it fails randomly, need to investigate
 
     return [os.path.normpath(it) for it in skip]
 

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -111,11 +111,11 @@ def get_conan_env(script):
 
 
 def configure_profile(env):
-    subprocess.Popen(["conan", "profile", "new", "default", "--detect"], stderr=subprocess.STDOUT, 
-                     shell=True, env=env)
+    subprocess.Popen(["conan profile new default --detect"], stderr=subprocess.STDOUT, 
+                     shell=True, env=env).communicate()[0]
     if platform.system() == "Linux":
-        subprocess.Popen(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"],
-                          stderr=subprocess.STDOUT, shell=True, env=env)
+        subprocess.Popen(["conan profile update settings.compiler.libcxx=libstdc++11 default"],
+                          stderr=subprocess.STDOUT, shell=True,env=env).communicate()[0]
 
 
 def print_build(script):

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -111,15 +111,11 @@ def get_conan_env(script):
 
 
 def configure_profile(env):
-    subprocess.check_output("conan profile new default --detect",
-                            stderr=subprocess.STDOUT,
-                            shell=True,
-                            env=env)
+    subprocess.Popen(["conan", "profile", "new", "default", "--detect"], stderr=subprocess.STDOUT, 
+                     shell=True, env=env)
     if platform.system() == "Linux":
-        subprocess.check_output("conan profile update settings.compiler.libcxx=libstdc++11 default",
-                                stderr=subprocess.STDOUT,
-                                shell=True,
-                                env=env)
+        subprocess.Popen(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"],
+                          stderr=subprocess.STDOUT, shell=True, env=env)
 
 
 def print_build(script):

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -111,10 +111,10 @@ def get_conan_env(script):
 
 
 def configure_profile(env):
-    subprocess.Popen(["conan", "profile", "new", "default", "--detect"], stderr=subprocess.STDOUT, env=env).communicate()[0]
+    subprocess.Popen(["conan", "profile", "new", "default", "--detect"], stderr=subprocess.STDOUT, env=env).communicate()
     if platform.system() == "Linux":
         subprocess.Popen(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"],
-                          stderr=subprocess.STDOUT, env=env).communicate()[0]
+                          stderr=subprocess.STDOUT, env=env).communicate()
 
 
 def print_build(script):

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -111,11 +111,10 @@ def get_conan_env(script):
 
 
 def configure_profile(env):
-    subprocess.Popen(["conan profile new default --detect"], stderr=subprocess.STDOUT, 
-                     shell=True, env=env).communicate()[0]
+    subprocess.Popen(["conan", "profile", "new", "default", "--detect"], stderr=subprocess.STDOUT, env=env).communicate()[0]
     if platform.system() == "Linux":
-        subprocess.Popen(["conan profile update settings.compiler.libcxx=libstdc++11 default"],
-                          stderr=subprocess.STDOUT, shell=True,env=env).communicate()[0]
+        subprocess.Popen(["conan", "profile", "update", "settings.compiler.libcxx=libstdc++11", "default"],
+                          stderr=subprocess.STDOUT, env=env).communicate()[0]
 
 
 def print_build(script):

--- a/.ci/run.py
+++ b/.ci/run.py
@@ -63,6 +63,8 @@ def get_examples_to_skip(current_version):
         # waf does not support Visual Studio 2019 for 2.0.19
         if os.environ["CMAKE_GENERATOR"] == "Visual Studio 2019":
             skip.extend(['./features/integrate_build_system', ])
+    if platform.system() == "Darwin":
+        skip.extend(['./features/multi_config', ]) # randomly failing in Macos
 
     return [os.path.normpath(it) for it in skip]
 


### PR DESCRIPTION
Skip multi_config example in Macos and executing conan profile init without shell.