### PR TITLE
Fix folly example

### DIFF
--- a/libraries/folly/basic/conanfile.txt
+++ b/libraries/folly/basic/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 folly/2019.10.21.00
+openssl/1.1.1k
 
 [generators]
 cmake


### PR DESCRIPTION
Overriding openssl to openssl/1.1.1k used by the cmake build_requires.
