### PR TITLE
Update protobuf example to work with Conan 2.0

### DIFF
--- a/libraries/protobuf/serialization/CMakeLists.txt
+++ b/libraries/protobuf/serialization/CMakeLists.txt
@@ -1,19 +1,16 @@
-cmake_minimum_required(VERSION 3.1.2)
+cmake_minimum_required(VERSION 3.15)
 project(sensor CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS)
-
-find_package(Protobuf REQUIRED)
+find_package(Protobuf REQUIRED CONFIG)
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS sensor.proto)
 protobuf_generate_python(PROTO_PYS sensor.proto)
 
 add_executable(${PROJECT_NAME} main.cc ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(${PROJECT_NAME} PUBLIC CONAN_PKG::protobuf)
+target_link_libraries(${PROJECT_NAME} PRIVATE protobuf::protobuf)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR})
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 11)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 add_custom_target(proto_python ALL DEPENDS ${PROTO_PYS})

--- a/libraries/protobuf/serialization/build.bat
+++ b/libraries/protobuf/serialization/build.bat
@@ -7,11 +7,12 @@ if "%CMAKE_GENERATOR%"=="" (
     MKDIR build
     PUSHD build
 
-    conan install ..
-    cmake .. -G "%CMAKE_GENERATOR%" -A "%CMAKE_GENERATOR_PLATFORM%"
+    conan install .. -pr:h=default -pr:b=default --build=missing
+    cmake .. -G "%CMAKE_GENERATOR%" -A "%CMAKE_GENERATOR_PLATFORM%" -DCMAKE_TOOLCHAIN_FILE==Release/generators/conan_toolchain.cmake
     cmake --build . --config Release
 
-    bin\sensor.exe
+    sensor.exe
 
+    SET PYTHONPATH="%CD%"
     python ../main.py
 )

--- a/libraries/protobuf/serialization/build.sh
+++ b/libraries/protobuf/serialization/build.sh
@@ -8,9 +8,9 @@ mkdir build
 pushd build
 
 conan install .. -pr:h=default -pr:b=default --build=missing
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=Release/generators/conan_toolchain.cmake
 cmake --build .
 
 ./sensor
 
-python ../main.py
+PYTHONPATH=${PWD} python ../main.py

--- a/libraries/protobuf/serialization/build.sh
+++ b/libraries/protobuf/serialization/build.sh
@@ -7,10 +7,10 @@ rm -rf build
 mkdir build
 pushd build
 
-conan install .. --build=missing
-cmake .. -DCMAKE_BUILD_TYPE=Release
+conan install .. -pr:h=default -pr:b=default --build=missing
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
 cmake --build .
 
-bin/sensor
+./sensor
 
 python ../main.py

--- a/libraries/protobuf/serialization/conanfile.txt
+++ b/libraries/protobuf/serialization/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
-protobuf/3.20.0
+protobuf/3.21.9
 
 [generators]
-cmake
+CMakeToolchain
+CMakeDeps

--- a/libraries/protobuf/serialization/conanfile.txt
+++ b/libraries/protobuf/serialization/conanfile.txt
@@ -1,6 +1,12 @@
 [requires]
 protobuf/3.21.9
 
+[tool_requires]
+protobuf/3.21.9
+
 [generators]
 CMakeToolchain
 CMakeDeps
+
+[layout]
+cmake_layout

--- a/libraries/protobuf/serialization/main.py
+++ b/libraries/protobuf/serialization/main.py
@@ -1,10 +1,10 @@
 import os
-from build.sensor_pb2 import Sensor
+from sensor_pb2 import Sensor
 
 if __name__ == "__main__":
     with open("sensor.data", 'rb') as file:
         content = file.read()
-        
+
     print("Retrieve Sensor object from sensor.data")
     sensor = Sensor()
     sensor.ParseFromString(content)

--- a/libraries/protobuf/serialization/sensor.proto
+++ b/libraries/protobuf/serialization/sensor.proto
@@ -1,4 +1,5 @@
-syntax = "proto2";
+syntax = "proto3";
+
 message Sensor {
   required string name = 1;
   required double temperature = 2;
@@ -10,4 +11,3 @@ message Sensor {
   }
   required SwitchLevel door = 4;
 }
-

--- a/libraries/protobuf/serialization/sensor.proto
+++ b/libraries/protobuf/serialization/sensor.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
 message Sensor {
-  required string name = 1;
-  required double temperature = 2;
-  required int32 humidity = 3;
+  string name = 1;
+  double temperature = 2;
+  int32 humidity = 3;
 
   enum SwitchLevel {
     CLOSED = 0;
     OPEN = 1;
   }
-  required SwitchLevel door = 4;
+  SwitchLevel door = 4;
 }


### PR DESCRIPTION
- Use CMakeToolchain + CMakeDeps + cmake_layout instead of legacy cmake generator
- Update Protobuf to the latest version available in Conan Center
- Use Protobuf syntax version 3 instead of 2 (legacy).
- Include protobuf as tool requirement too, to make possible to parse .proto file
- Use protobuf targets instead of old CONAN_PKG
